### PR TITLE
Python 3.6.2-alpine3.6 update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.1-alpine
+FROM python:3.6.2-alpine3.6
 
 ARG LIBRDKAFKA_NAME="librdkafka"
 ARG LIBRDKAFKA_VER="0.9.5"


### PR DESCRIPTION
Update the base image from python:3.6.1-alpine to
python:3.6.2-alpine3.6. In addition to updating Python, this also
switches from Alpine 3.4 to Alpine 3.6.